### PR TITLE
Add basic i18n support + English/French/German translations

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,74 @@
+[yields]
+other = "Zutaten für"
+
+[prepTime]
+other = "Vorbereitungszeit"
+
+[cookTime]
+other = "Koch-/Backzeit"
+
+[ingredients]
+other = "Zutaten"
+
+[directions]
+other = "Arbeitsschritte"
+
+[components]
+other = "Komponenten"
+
+[steps]
+other = "Arbeitsschritte"
+
+[category]
+other = "Kategorie"
+
+[cuisine]
+other = "Küche"
+
+[tags]
+other = "Tags"
+
+[inspired]
+other = "inspiriert"
+
+[by]
+other = "durch"
+
+[from]
+other = "von"
+
+[powered-by]
+other = "Powered by"
+
+[for-the-home-chef]
+other = "Für den Küchenchef"
+
+[save-recipes]
+other = "Speichern Sie Rezepte in Sekundenschnelle mit Klartextformatierung"
+
+[create-beautiful]
+other = "Erstellen Sie schöne Rezeptseiten mit automatisierter Leichtigkeit"
+
+[use-recipes]
+other = "Verwenden Sie Ihre Rezepte in jeder App"
+
+[our-favorite]
+other = "Unser Favorit ist"
+
+[share]
+other = "Teilen Sie mit Familie und Freunden"
+
+[for-the-developer]
+other = "Für den Entwickler"
+
+[markdown-hugo]
+other = "Markdown + Hugo under the hood"
+
+[recipes-stored]
+other = "Im Klartext gespeicherte Rezepte, bereit zum Hacken"
+
+[open-source]
+other = "Open source, alles ist auf GitHub"
+
+[contribute]
+other = "dazu beitragen"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -13,6 +13,12 @@ other = "ingredients"
 [directions]
 other = "directions"
 
+[components]
+other = "Components"
+
+[steps]
+other = "Steps"
+
 [category]
 other = "category"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,17 +1,17 @@
 [yields]
-other = "yields"
+other = "Yields"
 
 [prepTime]
-other = "prepTime"
+other = "Preparation time"
 
 [cookTime]
-other = "cookTime"
+other = "Cooking time"
 
 [ingredients]
-other = "ingredients"
+other = "Ingredients"
 
 [directions]
-other = "directions"
+other = "Directions"
 
 [components]
 other = "Components"
@@ -20,13 +20,13 @@ other = "Components"
 other = "Steps"
 
 [category]
-other = "category"
+other = "Category"
 
 [cuisine]
-other = "cuisine"
+other = "Cuisine"
 
 [tags]
-other = "tags"
+other = "Tags"
 
 [inspired]
 other = "inspired"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,68 @@
+[yields]
+other = "yields"
+
+[prepTime]
+other = "prepTime"
+
+[cookTime]
+other = "cookTime"
+
+[ingredients]
+other = "ingredients"
+
+[directions]
+other = "directions"
+
+[category]
+other = "category"
+
+[cuisine]
+other = "cuisine"
+
+[tags]
+other = "tags"
+
+[inspired]
+other = "inspired"
+
+[by]
+other = "by"
+
+[from]
+other = "from"
+
+[powered-by]
+other = "Powered by"
+
+[for-the-home-chef]
+other = "For the home chef"
+
+[save-recipes]
+other = "Save recipes in seconds with plain text formatting"
+
+[create-beautiful]
+other = "Create beautiful recipe pages with automated ease"
+
+[use-recipes]
+other = "Use your recipes in any app"
+
+[our-favorite]
+other = "our favorite is"
+
+[share]
+other = "Share with family and friends"
+
+[for-the-developer]
+other = "For the developer"
+
+[markdown-hugo]
+other = "Markdown + Hugo under the hood"
+
+[recipes-stored]
+other = "Recipes stored in plain text, ready for hacking"
+
+[open-source]
+other = "Open source, everything's on GitHub"
+
+[contribute]
+other = "contribute"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,68 @@
+[yields]
+other = "Pour"
+
+[prepTime]
+other = "Préparation"
+
+[cookTime]
+other = "Cuisson"
+
+[ingredients]
+other = "Ingrédients"
+
+[directions]
+other = "Instructions"
+
+[category]
+other = "Catégorie"
+
+[cuisine]
+other = "Type de cuisine"
+
+[tags]
+other = "tags"
+
+[inspired]
+other = "Inspiré"
+
+[by]
+other = "par"
+
+[from]
+other = "de"
+
+[powered-by]
+other = "Propulsé par"
+
+[for-the-home-chef]
+other = "Pour les cuistots"
+
+[save-recipes]
+other = "Enregistrez vos recettes en quelques secondes au format texte brut"
+
+[create-beautiful]
+other = "Créez de magnifiques pages de recettes de façon automatique"
+
+[use-recipes]
+other = "Réutilisez vos recettes dans n'importe quelle app"
+
+[our-favorite]
+other = "notre préférée est"
+
+[share]
+other = "Partagez avec vos amis et votre famille"
+
+[for-the-developer]
+other = "Pour le développeur"
+
+[markdown-hugo]
+other = "Markdown + Hugo sous le capot"
+
+[recipes-stored]
+other = "Les recettes sont stockées en texte brut, prêtes à être hackées"
+
+[open-source]
+other = "Open source, tout est sur Github"
+
+[contribute]
+other = "contribuez"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -13,6 +13,12 @@ other = "Ingrédients"
 [directions]
 other = "Instructions"
 
+[components]
+other = "Composantes"
+
+[steps]
+other = "Etapes"
+
 [category]
 other = "Catégorie"
 

--- a/layouts/components/single.html
+++ b/layouts/components/single.html
@@ -30,17 +30,17 @@
     <div class="clearfix mt3">
       {{ with .Params.yield }}
       <div class="sm-col sm-col-2">
-          <h4 class="blue mt0 mb2 xs-center">Yields: {{ . }}</h4>
+          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" }}: {{ . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">Preparation time: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" }}: {{ . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">Cooking time: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" }}: {{ . }}</h4>
       </div>
       {{ end }}
     </div>
@@ -62,7 +62,7 @@
         {{ end }}
 
         {{ with .Params.Ingredients }}
-        <h4 class="blue mt0 mb2 xs-center">Ingredients</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "ingredients" }}</h4>
         <ul itemprop="ingredients">
           <!-- list ingredients that make up recipe -->
           {{ range . }}
@@ -75,7 +75,7 @@
       </div>
 
       <div class="sm-col sm-col-6 lg-col-6 recipeItems">
-        <h4 class="blue mt0 mb2 xs-center">Directions</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "directions" }}</h4>
         <ul itemprop="recipeInstructions">
           {{ range .Params.Directions }}
           <li>

--- a/layouts/components/single.html
+++ b/layouts/components/single.html
@@ -50,7 +50,7 @@
       <div class="sm-col sm-col-6 lg-col-6 recipeItems">
         <!-- check if it's a component-based recipe -->
         {{ with .Params.Components}}
-        <h4 class="blue mt0 mb2 xs-center">Components</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "components" }}</h4>
         <ul>
           <!-- list components that make up recipe -->
           {{ range . }}
@@ -121,7 +121,7 @@
           {{ end }}
         </ul>
         
-        <h4 class="blue regular xs-center">Steps</h4>
+        <h4 class="blue regular xs-center">{{ i18n "steps" }}</h4>
         <ul itemprop="instructions">
           {{ range .Params.Directions }}
           <li>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
   {{ if not .Site.Params.hideCopyright }} © {{ now.Format "2006" }}{{ end }}
   {{ if not .Site.Params.hideCredits }}
     {{ if not .Site.Params.hideCopyright }} · {{ end }}
-    Powered by <a href="https://gohugo.io/">Hugo</a> &amp; <a href="https://github.com/seanlane/gochowdown">GoChowdown</a>
+    {{ i18n "powered-by" }} <a href="https://gohugo.io/">Hugo</a> &amp; <a href="https://github.com/seanlane/gochowdown">GoChowdown</a>
   {{ end }}
   {{ if .Site.Params.commit }}
     {{ if or (not .Site.Params.hideCredits) (not .Site.Params.hideCopyright) }} · {{ end }}

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -25,17 +25,17 @@
   <div class="sell bg-blue-tile mt4">
     <div class="clearfix white px2">
       <div class="sm-col md-col-6 px2 md-px4 py2 md-py4">
-        <h1>For the home chef</h1>
-        <p>Save recipes in seconds with plain text formatting</p>
-        <p>Create beatiful recipe pages with automated ease</p>
-        <p>Use your recipes in any app (our favorite is <a href="http://www.paprikaapp.com/" target="_blank">Paprika</a>)</p>
-        <p>Share with family and friends (<a href="https://dev.twitter.com/cards/overview">Twitter cards</a>)</p>
+        <h1>{{ i18n "for-the-home-chef" }}</h1>
+        <p>{{ i18n "save-recipes" }}</p>
+        <p>{{ i18n "create-beautiful" }}</p>
+        <p>{{ i18n "use-recipes" }} ({{ i18n "our-favorite" }} <a href="http://www.paprikaapp.com/" target="_blank">Paprika</a>)</p>
+        <p>{{ i18n "share" }} (<a href="https://dev.twitter.com/cards/overview">Twitter cards</a>)</p>
       </div>
       <div class="sm-col md-col-6 px2 md-px4 py2 md-py4">
-        <h1>For the developer</h1>
-        <p>Markdown + Hugo under the hood</p>
-        <p>Recipes stored in plain text, ready for hacking</p>
-        <p>Open source, everything's on GitHub (<a href="https://github.com/seanlane/gochowdown">contribute?</a>)</p>
+          <h1>{{ i18n "for-the-developer" }}</h1>
+          <p>{{ i18n "markdown-hugo" }}</p>
+          <p>{{ i18n "recipes-stored" }}</p>
+          <p>{{ i18n "open-source" }} (<a href="https://github.com/seanlane/gochowdown">{{ i18n "contribute" }}?</a>)</p>
       </div>
     </div>
     <div class="clearfix white center">

--- a/layouts/partials/taxonomy/category.html
+++ b/layouts/partials/taxonomy/category.html
@@ -1,5 +1,5 @@
 <div class="categories">
-  <p class="clearfix">Category: 
+  <p class="clearfix">{{ i18n "category"}}:
     <a href="{{ ( printf "category/%s/" ( . | urlize ) ) | relLangURL }}"><span itemprop="recipeCategory">{{ . | humanize }}</span></a>
   </p>
 </div>

--- a/layouts/partials/taxonomy/cuisine.html
+++ b/layouts/partials/taxonomy/cuisine.html
@@ -1,5 +1,5 @@
 <div class="categories">
-  <p class="clearfix">Cuisine: 
+  <p class="clearfix">{{ i18n "cuisine"}}:
     <a href="{{ ( printf "cuisine/%s/" ( . | urlize ) ) | relLangURL }}"><span itemprop="recipeCuisine">{{ . | humanize }}</span></a>
   </p>
 </div>

--- a/layouts/recipes/single.html
+++ b/layouts/recipes/single.html
@@ -30,17 +30,17 @@
     <div class="clearfix mt3">
       {{ with .Params.yield }}
       <div class="sm-col sm-col-2">
-          <h4 class="blue mt0 mb2 xs-center">Yields: {{ . }}</h4>
+          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" }}: {{ . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">Preparation time: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" }}: {{ . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">Cooking time: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" }}: {{ . }}</h4>
       </div>
       {{ end }}
     </div>
@@ -62,7 +62,7 @@
         {{ end }}
 
         {{ with .Params.Ingredients }}
-        <h4 class="blue mt0 mb2 xs-center">Ingredients</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "ingredients" }}</h4>
         <ul itemprop="ingredients">
           <!-- list ingredients that make up recipe -->
           {{ range . }}
@@ -75,7 +75,7 @@
       </div>
 
       <div class="sm-col sm-col-6 lg-col-6 recipeItems">
-        <h4 class="blue mt0 mb2 xs-center">Directions</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "directions" }}</h4>
         <ul itemprop="recipeInstructions">
           {{ range .Params.Directions }}
           <li>
@@ -142,15 +142,15 @@
     {{ with .Params.Category }}{{ partial "taxonomy/category" . }}{{ end }}
     {{ with .Params.Cuisine }}{{ partial "taxonomy/cuisine" . }}{{ end }}
     {{ with .Params.Tags }}{{ partial "taxonomy/tags" . }}{{ end }}
-    
+
     <div class="recipe-source">
       {{ if (or .Params.SourceName .Params.AuthorName) }}
-        inspired
+        {{ i18n "inspired" }}
       {{ end }}
 
       {{ with .Params.SourceName }}
         {{$name := .}}
-        by
+        {{ i18n "by" }}
         {{with $.Params.SourceURL }}
           <a href="{{.}}">{{$name}}</a>
          {{else}}
@@ -160,7 +160,7 @@
 
       {{with .Params.AuthorName}}
         {{$name := .}}
-        from
+        {{ i18n "from" }}
         {{with $.Params.AuthorURL }}
           <a href="{{.}}">{{$name}}</a>
          {{else}}

--- a/layouts/recipes/single.html
+++ b/layouts/recipes/single.html
@@ -50,7 +50,7 @@
       <div class="sm-col sm-col-6 lg-col-6 recipeItems">
         <!-- check if it's a component-based recipe -->
         {{ with .Params.Components}}
-        <h4 class="blue mt0 mb2 xs-center">Components</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "components" }}</h4>
         <ul>
           <!-- list components that make up recipe -->
           {{ range . }}
@@ -121,7 +121,7 @@
           {{ end }}
         </ul>
 
-        <h4 class="blue regular xs-center">Steps</h4>
+        <h4 class="blue regular xs-center">{{ i18n "steps" }}</h4>
         <ul itemprop="instructions">
           {{ range .Params.Directions }}
           <li>


### PR DESCRIPTION
I used this documentation to add i18n string translation: https://gohugo.io/content-management/multilingual/#translation-of-strings

I also added the following configuration in my `config.toml`:

```
defaultContentLanguage = "fr"

[languages]
[languages.en]
weight = 0
title = "my title"
[languages.fr]
weight = 1
title = "mon titre"
```

You can test rendering by using `hugo serve -D --i18n-warnings` in case of missing translations