### PR TITLE
Several language improvements

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,11 +1,11 @@
 [yields]
-other = "Zutaten für"
+other = "Zutaten für: {{.}}"
 
 [prepTime]
-other = "Vorbereitungszeit"
+other = "Vorbereitungszeit: {{.}}"
 
 [cookTime]
-other = "Koch-/Backzeit"
+other = "Koch-/Backzeit: {{.}}"
 
 [ingredients]
 other = "Zutaten"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,11 +1,11 @@
 [yields]
-other = "Yields"
+other = "Yields: {{.}}"
 
 [prepTime]
-other = "Preparation time"
+other = "Preparation time: {{.}}"
 
 [cookTime]
-other = "Cooking time"
+other = "Cooking time: {{.}}"
 
 [ingredients]
 other = "Ingredients"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,11 +1,11 @@
 [yields]
-other = "Pour"
+other = "Pour: {{.}}"
 
 [prepTime]
-other = "Préparation"
+other = "Préparation: {{.}}"
 
 [cookTime]
-other = "Cuisson"
+other = "Cuisson: {{.}}"
 
 [ingredients]
 other = "Ingrédients"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -2,7 +2,7 @@
 # Copyright © 2021 Casper Meijn <casper@meijn.net>
 
 [yields]
-other = "Opbrengst: {{.}}"
+other = "Genoeg voor: {{.}}"
 
 [prepTime]
 other = "Bereidingstijd: {{.}}"
@@ -14,7 +14,7 @@ other = "Baktijd: {{.}}"
 other = "Ingrediënten"
 
 [directions]
-other = "Instructies"
+other = "Bereiding"
 
 [components]
 other = "Onderdelen"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -2,13 +2,13 @@
 # Copyright © 2021 Casper Meijn <casper@meijn.net>
 
 [yields]
-other = "Opbrengst"
+other = "Opbrengst: {{.}}"
 
 [prepTime]
-other = "Bereidingstijd"
+other = "Bereidingstijd: {{.}}"
 
 [cookTime]
-other = "Baktijd"
+other = "Baktijd: {{.}}"
 
 [ingredients]
 other = "Ingrediënten"

--- a/layouts/components/single.html
+++ b/layouts/components/single.html
@@ -30,17 +30,17 @@
     <div class="clearfix mt3">
       {{ with .Params.yield }}
       <div class="sm-col sm-col-2">
-          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" }}: {{ . }}</h4>
+          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" }}: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" }}: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" . }}</h4>
       </div>
       {{ end }}
     </div>

--- a/layouts/components/single.html
+++ b/layouts/components/single.html
@@ -29,17 +29,17 @@
 
     <div class="clearfix mt3">
       {{ with .Params.yield }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
           <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
         <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
         <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" . }}</h4>
       </div>
       {{ end }}

--- a/layouts/recipes/single.html
+++ b/layouts/recipes/single.html
@@ -30,17 +30,17 @@
     <div class="clearfix mt3">
       {{ with .Params.yield }}
       <div class="sm-col sm-col-2">
-          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" }}: {{ . }}</h4>
+          <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" }}: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
       <div class="sm-col sm-col-2">
-        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" }}: {{ . }}</h4>
+        <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" . }}</h4>
       </div>
       {{ end }}
     </div>

--- a/layouts/recipes/single.html
+++ b/layouts/recipes/single.html
@@ -29,17 +29,17 @@
 
     <div class="clearfix mt3">
       {{ with .Params.yield }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
           <h4 class="blue mt0 mb2 xs-center">{{ i18n "yields" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.prepTime }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
         <h4 class="blue mt0 mb2 xs-center">{{ i18n "prepTime" . }}</h4>
       </div>
       {{ end }}
       {{ with .Params.cookTime }}
-      <div class="sm-col sm-col-2">
+      <div class="sm-col sm-col-3">
         <h4 class="blue mt0 mb2 xs-center">{{ i18n "cookTime" . }}</h4>
       </div>
       {{ end }}


### PR DESCRIPTION
- Move parameters of yield, prep time and cook time to translation to increase the flexibility of the translation
- Use better words for the Dutch translation
- Increase size of yield, prep time and cook time fields, to make room for languages with longer words