### PR TITLE
fix: Replace deprecated functions

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -3,7 +3,9 @@ disablePathToLower: true
 languageCode: en-us
 title: My Recipes
 theme: gochowdown
-googleAnalytics: 
+services:
+  googleAnalytics:
+    ID:
 defaultcontentlanguage: en
 paginate: 20
 canonifyurls: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://unpkg.com/normalize.css@8.0.1/normalize.css" integrity="sha384-M86HUGbBFILBBZ9ykMAbT3nVb0+2C7yZlF8X2CiKNpDOQjKroMJqIeGZ/Le8N2Qp" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css" integrity="sha384-b92sF+wDNTHrfEtRaYo+EpcA8FUyHOSXrdxKc9XB9kaaX1rSQAgMevW6cYeE5Bdv" crossorigin="anonymous">
-  {{ if .Site.IsServer }}
+  {{ if hugo.IsServer }}
     {{ $cssOpts := (dict "targetPath" "css/gochowdown.css" "enableSourceMap" true ) }}
     {{ $styles := resources.Get "scss/gochowdown.scss" | resources.ExecuteAsTemplate "style.gochowdown.css" . | toCSS $cssOpts }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" media="screen">
@@ -37,8 +37,6 @@
       {{ block "content" . }}{{ end }}
     </main>
     {{ partial "footer.html" . }}
-    {{ if .Site.GoogleAnalytics }}
-      {{ template "_internal/google_analytics.html" . }}
-    {{ end }}
+    {{ template "_internal/google_analytics.html" . }}
   </body>
 </html>


### PR DESCRIPTION
Hugo v0.120 deprecated both:
- .Site.IsServer which is replaced by hugo.IsServer
- .Site.GoogleAnalytics which is replaced by Site.Config.Services.GoogleAnalytics.ID

It seems template `google_analytics.html` checks for an ID itself, so we can remove the check.

This change increases the minimum version to hugo v0.120 released on Oct 30, 2023.

Tested with hugo v0.132.1-1bde700dfc0770bb11eb8445aff1ab5abdccb46e+extended