### PR TITLE
docs: Remove `canonifyURLs` from example config

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -6,7 +6,6 @@ theme: gochowdown
 googleAnalytics: 
 defaultcontentlanguage: en
 paginate: 20
-canonifyurls: true
 pygmentsstyle: monokai
 pygmentscodefences: true
 pygmentscodefencesguesssyntax: true


### PR DESCRIPTION
The `canonifyURLs` configuration option broke my site with hugo version 0.132. It seems that it is discouraged to use that option [source]. I think it should be removed from the example config.

[source]: https://gohugo.io/content-management/urls/#canonical-urls