### PR TITLE
fix: Use Permalink for absolute links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,11 +16,11 @@
   {{ if .Site.IsServer }}
     {{ $cssOpts := (dict "targetPath" "css/gochowdown.css" "enableSourceMap" true ) }}
     {{ $styles := resources.Get "scss/gochowdown.scss" | resources.ExecuteAsTemplate "style.gochowdown.css" . | toCSS $cssOpts }}
-    <link rel="stylesheet" href="{{ $styles.RelPermalink }}" media="screen">
+    <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
   {{ else }}
     {{ $cssOpts := (dict "targetPath" "css/gochowdown.css" ) }}
     {{ $styles := resources.Get "scss/gochowdown.scss" | resources.ExecuteAsTemplate "style.gochowdown.css" . | toCSS $cssOpts | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous" media="screen" />
+    <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous" media="screen" />
   {{ end }}
   
   {{ range .Site.Params.custom_css }}

--- a/layouts/components/single.html
+++ b/layouts/components/single.html
@@ -12,7 +12,7 @@
   {{ else }}
     {{ range first 1 (.Resources.ByType "image") }}
       <div class="xs-p2">
-        <img itemprop="image" src="{{$.Site.BaseURL}}{{ .RelPermalink }}" />
+        <img itemprop="image" src="{{ .Permalink }}" />
       </div>
     {{ end }}
   {{ end }}
@@ -99,8 +99,8 @@
       {{ range where $.Site.Pages "Title" $compTitle }}
         <h4 class="blue center">{{ .Title }}</h4>
         {{ range (.Resources.ByType "image") }}
-        <div class="image ratio bg-cover" style="background-image:url({{$.Site.BaseURL}}{{ .RelPermalink }});">
-          <img class="hide" itemprop="photo" src="{{$.Site.BaseURL}}{{ .RelPermalink }}" />
+        <div class="image ratio bg-cover" style="background-image:url({{ .Permalink }});">
+          <img class="hide" itemprop="photo" src="{{ .Permalink }}" />
         </div>
         {{ end }}
         {{ if .Params.Imagecredit }}

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -3,7 +3,7 @@
     <div class="clearfix">
     {{ range sort (where .Site.RegularPages "Section" "recipes") "Title" }}
       <div class="sm-col sm-col-6 md-col-6 lg-col-4 xs-px1 xs-mb2">
-          <a class="block relative bg-blue" href="{{ .RelPermalink }}">
+          <a class="block relative bg-blue" href="{{ .Permalink }}">
             {{ if .Params.Image }}
               <div class="image ratio bg-cover" style="background-image:url({{.Permalink}}{{ .Params.Image }});"></div>
             {{ else }}

--- a/layouts/recipes/single.html
+++ b/layouts/recipes/single.html
@@ -12,7 +12,7 @@
   {{ else }}
     {{ range first 1 (.Resources.ByType "image") }}
       <div class="xs-p2">
-        <img itemprop="image" src="{{$.Site.BaseURL}}{{ .RelPermalink }}" />
+        <img itemprop="image" src="{{ .Permalink }}" />
       </div>
     {{ end }}
   {{ end }}
@@ -99,8 +99,8 @@
       {{ range where $.Site.Pages "Title" $compTitle }}
         <h4 class="blue center"><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
         {{ range (.Resources.ByType "image") }}
-        <div class="image ratio bg-cover" style="background-image:url({{$.Site.BaseURL}}{{ .RelPermalink }});">
-          <img class="hide" itemprop="photo" src="{{$.Site.BaseURL}}{{ .RelPermalink }}" />
+        <div class="image ratio bg-cover" style="background-image:url({{ .Permalink }});">
+          <img class="hide" itemprop="photo" src="{{ .Permalink }}" />
         </div>
         {{ end }}
         {{ if .Params.Imagecredit }}


### PR DESCRIPTION
Use Permalink to create absolute links instead of trying to construct it ourselves using (BaseUrl + RelPermalink).

I also removed other calls to RelPermalink to be consistent and always use absolute URLs.